### PR TITLE
chore: update installed casks (add cursor, remove zoom/iterm2/vscode)

### DIFF
--- a/macos/install.sh
+++ b/macos/install.sh
@@ -13,12 +13,11 @@ echo "› sudo softwareupdate -i -a"
 
 brew install tldr htop hub kubectx kube-ps1 krew starship
 
-brew install --cask visual-studio-code \
-  1password \
+brew install --cask 1password \
   arc \
+  cursor \
   google-cloud-sdk \
   jetbrains-toolbox \
-  iterm2 \
   obsidian \
   handbrake \
   rectangle \
@@ -31,5 +30,4 @@ brew install --cask visual-studio-code \
   superhuman \
   figma \
   sonos \
-  vlc \
-  zoom
+  vlc


### PR DESCRIPTION
## Summary

- **Remove** `zoom`, `iterm2`, and `visual-studio-code` from the Homebrew cask install list in `macos/install.sh`
- **Add** `cursor` (AI code editor) positioned alphabetically after `arc`

## Changes

| Action | Cask |
|--------|------|
| ➕ Added | `cursor` |
| ➖ Removed | `visual-studio-code` |
| ➖ Removed | `iterm2` |
| ➖ Removed | `zoom` |

## Test plan

- [ ] Run `macos/install.sh` on a fresh macOS setup and verify `cursor` is installed
- [ ] Confirm `zoom`, `iterm2`, and `visual-studio-code` are no longer pulled in by this script

🤖 Generated with [Claude Code](https://claude.com/claude-code)