### PR TITLE
fix: support macOS Bash in module loading

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -35,7 +35,12 @@ displayUsageAndExit() {
 }
 
 save_modules() {
-	mapfile -t modules < <(dotfiles_resolve_modules "$@")
+	local module
+	local modules=()
+
+	while IFS= read -r module; do
+		[ -n "$module" ] && modules+=("$module")
+	done < <(dotfiles_resolve_modules "$@")
 	dotfiles_write_enabled "${modules[@]}"
 }
 
@@ -44,9 +49,15 @@ add_modules() {
 	local current=()
 	local requested=()
 
-	mapfile -t current < <(dotfiles_enabled_modules)
-	mapfile -t requested < <(dotfiles_resolve_modules "$@")
-	mapfile -t modules < <(printf '%s\n' "${current[@]}" "${requested[@]}" | dotfiles_unique_modules)
+	while IFS= read -r module; do
+		[ -n "$module" ] && current+=("$module")
+	done < <(dotfiles_enabled_modules)
+	while IFS= read -r module; do
+		[ -n "$module" ] && requested+=("$module")
+	done < <(dotfiles_resolve_modules "$@")
+	while IFS= read -r module; do
+		[ -n "$module" ] && modules+=("$module")
+	done < <(printf '%s\n' "${current[@]}" "${requested[@]}" | dotfiles_unique_modules)
 	dotfiles_write_enabled "${modules[@]}"
 }
 
@@ -56,8 +67,12 @@ remove_modules() {
 	local requested=()
 	local next=()
 
-	mapfile -t current < <(dotfiles_enabled_modules)
-	mapfile -t requested < <(dotfiles_resolve_modules "$@")
+	while IFS= read -r module; do
+		[ -n "$module" ] && current+=("$module")
+	done < <(dotfiles_enabled_modules)
+	while IFS= read -r module; do
+		[ -n "$module" ] && requested+=("$module")
+	done < <(dotfiles_resolve_modules "$@")
 
 	for module in "${current[@]}"; do
 		remove=false
@@ -76,8 +91,11 @@ remove_modules() {
 
 run_update() {
 	export ZSH="${ZSH:-$HOME/.dotfiles}"
+	local module
 	local enabled=()
-	mapfile -t enabled < <(dotfiles_enabled_modules)
+	while IFS= read -r module; do
+		[ -n "$module" ] && enabled+=("$module")
+	done < <(dotfiles_enabled_modules)
 
 	if dotfiles_contains_module macos "${enabled[@]}"; then
 		"$ZSH/macos/set-defaults.sh"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -147,7 +147,10 @@ install_dotfiles () {
   done
 }
 
-mapfile -t modules < <(dotfiles_resolve_modules "$@")
+modules=()
+while IFS= read -r module; do
+  [ -n "$module" ] && modules+=("$module")
+done < <(dotfiles_resolve_modules "$@")
 dotfiles_write_enabled "${modules[@]}"
 
 if dotfiles_contains_module git "${modules[@]}"; then

--- a/script/install
+++ b/script/install
@@ -8,7 +8,10 @@ cd "$(dirname "$0")/.."
 
 source script/lib/modules.sh
 
-mapfile -t modules < <(dotfiles_resolve_modules "$@")
+modules=()
+while IFS= read -r module; do
+  [ -n "$module" ] && modules+=("$module")
+done < <(dotfiles_resolve_modules "$@")
 
 for module in "${modules[@]}"; do
   installer="$DOTFILES_ROOT/$module/install.sh"


### PR DESCRIPTION
### Motivation
- macOS ships with Bash 3 by default which lacks `mapfile`/`readarray`, causing `script/bootstrap` and related commands to fail on Mac.
- Make module resolution and the `dot` CLI work reliably across systems without requiring a newer shell.

### Description
- Replace Bash 4 `mapfile` usage with POSIX-friendly `while IFS= read -r` loops that populate arrays in `script/bootstrap`, `script/install`, and `bin/dot`.
- Update `bin/dot`'s `save_modules`, `add_modules`, `remove_modules`, and `run_update` logic to read module lists via portable `while read` loops instead of `mapfile`.
- Ensure `script/bootstrap` and `script/install` resolve modules into arrays using the same portable pattern so profiles and installs behave the same on macOS.

### Testing
- Static syntax check with `bash -n script/bootstrap script/install bin/dot script/lib/modules.sh` succeeded.
- Isolated bootstrap run with `HOME="$TMP" DOTFILES_CONFIG_HOME="$TMP/config" script/bootstrap profile minimal` verified expected `config/enabled` contents and created symlinks.
- Isolated CLI flow with `HOME="$TMP" DOTFILES_CONFIG_HOME="$TMP/config" bin/dot profile minimal` plus `bin/dot enable git` and `bin/dot disable git` verified module enable/disable behavior.
- All automated shell, bootstrap, and module-management checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cbc62c084832b8d4fa4658ca66bf4)